### PR TITLE
picklist values fixes #219

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Custom Data types (the component extendedDatatable extends lightning:datatable) 
 `type` : This key is for the override column Type :
 - [supported_lwc_datatable_datatype](https://developer.salesforce.com/docs/component-library/bundle/lightning-datatable/documentation). ( Ex : `url` ). ( [Example : Related Field Customized](#related-field-customized) )
 - [lookup editable column](#lookup-editable-column)
-- [picklist editable column](#picklist-column)
+- [picklist column](#picklist-column)
 
 `typeAttributes` : This key is used for custom columns :
 - a hyperlink to recordId (id of the current detail page) ( `recId` stored recordId Field ). ( [Example : Add Hyperlink for navigate to record](#example--add-hyperlink-for-navigate-to-record) )
@@ -106,7 +106,7 @@ Here the lookup will not be editable (to have editable lookup field see #lookup-
 
 #### Picklist column
 
-By default, you don't need to insert JSON for a picklist field, the field is editable by default. However you might have the following use cases :
+By default, you don't need to insert JSON for a picklist field, the field is editable by default. However, you might have the following use cases :
 
 **make the picklist field non-editable**
 ```yml

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Custom Data types (the component extendedDatatable extends lightning:datatable) 
 `type` : This key is for the override column Type :
 - [supported_lwc_datatable_datatype](https://developer.salesforce.com/docs/component-library/bundle/lightning-datatable/documentation). ( Ex : `url` ). ( [Example : Related Field Customized](#related-field-customized) )
 - [lookup editable column](#lookup-editable-column)
-- [picklist editable column](#picklist-editable-column)
+- [picklist editable column](#picklist-column)
 
 `typeAttributes` : This key is used for custom columns :
 - a hyperlink to recordId (id of the current detail page) ( `recId` stored recordId Field ). ( [Example : Add Hyperlink for navigate to record](#example--add-hyperlink-for-navigate-to-record) )
@@ -93,21 +93,26 @@ Custom Data types (the component extendedDatatable extends lightning:datatable) 
 
 When overriding columns you can override different columns for the different uses cases :
 - [lookup editable column](#lookup-editable-column)
-- [picklist editable column](#picklist-editable-column)
+- [picklist column](#picklist-column)
 - [hyperlink to navigate to the record](#add-a-hyperlink-to-navigate-to-the-record)
 
 #### Related Field Customized
+
+Here the lookup will not be editable (to have editable lookup field see #lookup-editable-column)
 
 ```yml
 { "Account.Name": { "label": "Account Name", "type": "text" } }
 ```
 
-#### Picklist editable column
+#### Picklist column
 
+By default, you don't need to insert JSON for a picklist field, the field is editable by default. However you might have the following use cases :
+
+**make the picklist field non-editable**
 ```yml
-    {"StageName" : {"type": "picklist"} }
+    {"StageName" : {"type": "text", "editable": false} }
 ```
-you can also override the label
+**you can also override the label**
 
 ```yml
     {"StageName" : {"label": "Step", "type": "picklist"} }

--- a/force-app/main/default/classes/RelatedList.cls
+++ b/force-app/main/default/classes/RelatedList.cls
@@ -136,9 +136,10 @@ public with sharing class RelatedList {
                         }
                     }
 
+                    String type = mapPreCols.get(fieldName).type;
                     mapPreCols = checkOverride(mapPreCols, fieldName, mfields);
-                    //check if the field is of type picklist in config => if so allow edit
-                    if(mapPreCols.get(fieldName).type == 'picklist') {
+                    //picklist list are set to editable by default, non editable picklist field are defined in the readme
+                    if(String.isBlank(type) && mapPreCols.get(fieldName).type == 'picklist') {
                         RelatedList.initPicklistColumn(
                             mapPreCols,
                             objectName,

--- a/force-app/main/default/classes/RelatedList.cls
+++ b/force-app/main/default/classes/RelatedList.cls
@@ -124,7 +124,7 @@ public with sharing class RelatedList {
                             mapPreCols.get(fieldName).typeAttributes = new TypeAttributeColumnLookup();
                         }
                         when 'picklist' {
-                            //set picklistValues for picklist type
+                            //check if the field is of type picklist in custom json => if so allow edit
                             RelatedList.initPicklistColumn(
                                 mapPreCols,
                                 objectName,
@@ -137,6 +137,14 @@ public with sharing class RelatedList {
                     }
 
                     mapPreCols = checkOverride(mapPreCols, fieldName, mfields);
+                    //check if the field is of type picklist in config => if so allow edit
+                    if(mapPreCols.get(fieldName).type == 'picklist') {
+                        RelatedList.initPicklistColumn(
+                            mapPreCols,
+                            objectName,
+                            fieldName
+                        );
+                    }
                 }
             }
             return new ListResults(


### PR DESCRIPTION
# Description
@Sarveshgithub all good,

When we retrieve the type picklist for a field and there is no more customized json required for that field :  retrieved the picklist values

Fixes #219

## Type of change
-   Bug fix (non-breaking change which fixes an issue)
- readme changed

# How Has This Been Tested?

-   [ ] StageName for Opportunity without defining customized json
